### PR TITLE
WIP: Shared Memory data node

### DIFF
--- a/src/ComputeFramework.jl
+++ b/src/ComputeFramework.jl
@@ -69,6 +69,8 @@ include("macros.jl")
 include("optimize.jl")
 
 include("data-nodes/dist-memory/compute.jl")
+include("data-nodes/shared-memory/compute.jl")
+
 include("show.jl")
 
 end # module

--- a/src/data-nodes/shared-memory/compute.jl
+++ b/src/data-nodes/shared-memory/compute.jl
@@ -60,8 +60,8 @@ Computing a MapPartNode on a SharedMemory datanode will return a DistMemory
 datanode distributed among the targets of SharedMemory.
 """
 function compute{N, T<:SharedMemory}(ctx, node::MapPartNode{NTuple{N, T}})
-    refsets = zip(map(x -> map(y->y[2], refs(x)), node.input)...) |> collect
-    pids = map(x->x[1], refs(node.input[1]))
+    refsets = zip(map(x -> map(y->y[2], x.refs), node.input)...) |> collect
+    pids = map(x->x[1], node.input[1].refs)
     pid_chunks = zip(pids, map(tuplize, refsets)) |> collect
 
     let f = node.f
@@ -92,5 +92,6 @@ end
 #Doesn't work nicely. Maybe create an mmaped file and grow it with the others?
 #Or return all the remoterefs to the mmaps rather than concatenating them?
 function gather{n}(ctx, p::BytesPartition{n}, xs::Vector)
-    warn("BytesPartition should be used with SharedMemory only.") 
+    #warn("BytesPartition should be used with SharedMemory only.") 
+    xs #Returns the mmaps
 end

--- a/src/data-nodes/shared-memory/compute.jl
+++ b/src/data-nodes/shared-memory/compute.jl
@@ -1,0 +1,91 @@
+"""
+Compute node for Files/IO.
+Computing these will result in a `SharedMemory` data node with
+the offsets on the data node as specified by the Partition.
+"""
+
+immutable FileBlocks{P <: AbstractPartition} <: ComputeNode
+    uri::AbstractString #Change to URI
+    partition::P
+end
+
+FileBlocks(uri::AbstractString) = FileBlocks(uri, BytesPartition{nworkers()}())
+
+"""
+Data Node for Shared Memory. (Dist File?)
+This contains the mmaped file handle, the offset mapping to the processes and the
+partition.
+This node basically means the data has been created into an mmaped file and we
+have a pid -> offset/BlockIO ref mapping set up.
+"""
+immutable SharedMemory{P<:AbstractPartition} <: DataNode
+    sharedarray::Array #Entire mmaped file
+    offsets::Vector #Mapping btwn PIDs and the offsets they are responsible for.
+    refs::Vector #RemoteRefs to the mmaps on each process.
+    partition::P
+end
+
+function gather(ctx, n::SharedMemory)
+    #This returns the entire mmap. Partition does not matter.
+    #Write to a file and return the file handle here?
+    n.sharedarray
+end
+
+##### Compute #####
+
+"""
+Computing a FileBlock, will create a SharedMemory with the specified partition.
+"""
+function compute(ctx, x::FileBlocks)
+    targets = chunk_targets(ctx, x)
+    f = open(x.uri) #Opens a file handle to the file on the FileSystem
+    #Reading them as bytes.
+    sharedarray = Mmap.mmap(f, Vector{UInt8}, filesize(f)-1, shared=true)
+    offsets = slice(ctx, x.uri, x.partition, targets) #Expects a vector of ranges
+    refs = Pair[
+        (targets[i] => remotecall(
+                targets[i], 
+                (x, y) -> Mmap.mmap(x, Vector{UInt8}, (y.stop - y.start + 1,), y.start),
+                x.uri,
+                offsets[i]
+            )
+        )
+        for i in 1:length(targets)
+        ]
+    SharedMemory(sharedarray, offsets, refs, x.partition)
+end
+"""
+function compute{N, T<:SharedMemory}(ctx, node::MapPartNode{NTuple{N, T}})
+    refsets = zip(map(x -> map(y->y[2], refs(x)), node.input)...) |> collect
+    pids = map(x->x[1], refs(node.input[1]))
+    pid_chunks = zip(pids, map(tuplize, refsets)) |> collect
+
+    let f = node.f
+        futures = Pair[pid => @spawnat pid f(map(fetch, rs)...)
+                        for (pid, rs) in pid_chunks]
+        DistMemory(futures, node.input[1].partition)
+    end
+end"""
+##### Partition ####
+
+immutable BytesPartition{n} <: AbstractPartition end
+bytespartition(n) = BytesPartition{n}
+
+function byte_splits(startpos, fsize, parts)
+    @show len = fsize - startpos
+    starts = len >= parts ?
+        round(Int, linspace(0, len, parts+1)) :
+        [[0:len;], zeros(Int, parts-len);]
+    map((x,y) -> x:y, starts[1:end-1], starts[2:end] .- 1)
+end
+
+function slice{n}(ctx, uri, ::BytesPartition{n}, targets)
+    f = open(uri)
+    show offsets = byte_splits(position(f), filesize(f), length(targets)) 
+end
+
+#Doesn't work nicely. Maybe create an mmaped file and grow it with the others?
+#Or return all the remoterefs to the mmaps rather than concatenating them?
+function gather{n}(ctx, p::BytesPartition{n}, xs::Vector)
+    warn("BytesPartition should be used with SharedMemory only.") 
+end


### PR DESCRIPTION
`FileBlocks` compute node which can be computed to result in a `SharedMemory` data node.
The `SharedMemory` datanode creates a mmap array for the entire file, and splits the file to processes as per the offset ranges returned by the partition. Each process also has a mmap array open with the specified offsets (and length) and refs to these are stored with the pids. A gather on a `SharedMemory` returns the entire mmaped array.

`BytesPartition` returns offsets dividing the file on the basis of its filesize in terms of bytes. 

A `MapPartNode` on a `SharedMemory` results in a `DistMemory` with the results of the map operation stored at each chunk. A `gather` on a `DistMemory` with a `BytesPartition` results in a Array of the results at each process.