### PR TITLE
Implementing BFS over ComputeFramework

### DIFF
--- a/examples/bfs.jl
+++ b/examples/bfs.jl
@@ -1,0 +1,60 @@
+
+addprocs(2)
+
+# Map function for BFS. Returns all vertices reachable from the input vertex
+@everywhere function mapBFS(t)
+  u = t[1]
+  d = t[2]
+  [(v,d+1) for v::Int in find(sparseMatrix[u,:])]
+end
+
+# Filter function for BFS. Discard already-explored vertices
+@everywhere function filterBFS(tuple)
+  u,d = tuple
+  if dist[u] < 0
+    dist[u] = d
+    return true
+  else
+    return false
+  end
+end
+
+
+using ComputeFramework
+
+@everywhere numVertices = 8
+@everywhere adjacencyMatrix =  [ 0  1  1  1  0  0  0  0;
+                                 1  0  1  0  1  1  0  0;
+                                 1  1  0  1  0  1  1  0;
+                                 1  0  1  0  0  0  1  0;
+                                 0  1  0  0  0  1  0  1;
+                                 0  1  1  0  1  0  1  1;
+                                 0  0  1  1  0  1  0  1;
+                                 0  0  0  0  1  1  1  0;
+                                ]
+
+@everywhere sparseMatrix = sparse(adjacencyMatrix)
+
+#place distance vector in shared memory and initialize it in parallel.
+ldist = SharedArray(Int, numVertices, init = dist -> dist[Base.localindexes(dist)] = -1)
+@everywhere dist = nothing
+for p in procs()
+  @spawnat p (global dist;dist = ldist)
+end
+yield()
+
+# We could also use multiple seeds
+dist[1] = 0
+seedVertex = 1
+Q = [(seedVertex,0)]
+
+# Main BFS loop that implements iterative map-reduce-filter
+while length(Q) > 0
+  s1 = map(mapBFS, distribute(Q))    # explore new vertices
+  s2 = reduce(vcat, [], s1)          # concatenate the lists of tuples produced in map stage
+  s3 = compute(Context(), s2)
+  Q = gather(Context(), filter(filterBFS, distribute(s3)))
+  println(Q)
+end
+
+println(dist)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,3 +5,11 @@ using Base.Test
 
 x = rand(100, 100)
 @test gather(Context(), map(-, distribute(x))) == -x
+
+numbers = [1, 2, 3 ,4, 5, 6, 7, 8, 9, 10]
+
+# Test for reduce
+@test compute(Context(), reduce(+, 0, distribute(numbers))) == 55
+
+# Test for filter
+@test gather(Context(), filter(x -> x>3, distribute(numbers))) == [4,5,6,7,8,9,10]


### PR DESCRIPTION
This is an attempt at implementing BFS. I managed to get map to work, but I got a convert error on reduce and filter went into a stackoverflow. Not sure what I'm doing wrong.

Design issues I've faced are:

- The datastructure to store the graph. @ViralBShah recommended a sparse matrix, but I've found a list of lists to work better for BFS. The graph needs to be accessible by all worker processes. One strategy is to use `DistributedArrays`, and the second is to use `SharedArray`. However I couldn't create a SharedArray of type `Vector{Int}` (it requires a bits type) .
- The distance vector must be available to all worker processes, and be write synchronized. I implemented this as a SharedArray. But how do I reference this array in the worker processes (inside `filterBFS`).
- Do I use a single seed vertex or can I use multiple? A single seed vertex wastes the first iteration.