### PR TITLE
Fix #3 by fixing infinite loop

### DIFF
--- a/src/compute-nodes.jl
+++ b/src/compute-nodes.jl
@@ -107,7 +107,7 @@ end
 filter(f, x::AbstractNode) = FilterNode(f, x)
 
 function compute(ctx, node::FilterNode)
-    compute(ctx, mappart(part -> filter(node.f, part), node))
+    compute(ctx, mappart(part -> filter(node.f, part), node.input))
 end
 
 ### GroupBy ###


### PR DESCRIPTION
Instead of creating a MapPartNode for the `FilterNode`, create it for the input node of the `FilterNode`. This prevents the infinite loop in #3.