### PR TITLE
fix accumulators

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.4
+Compat

--- a/examples/count.jl
+++ b/examples/count.jl
@@ -11,3 +11,5 @@ acc = Accumulator(+, 0.0)
 end
 
 @show get(acc)
+
+release(acc)

--- a/examples/filewc.jl
+++ b/examples/filewc.jl
@@ -1,0 +1,10 @@
+addprocs(3)
+
+using ComputeFramework
+
+words = split(TextFile("text8"), ' ')
+
+count_one = map(x -> x => 1, words)
+wcount = reducebykey(+, 0, count_one)
+
+@show compute(Context(), wcount)

--- a/src/ComputeFramework.jl
+++ b/src/ComputeFramework.jl
@@ -1,5 +1,7 @@
 module ComputeFramework
 
+using Compat
+
 export compute, gather
 
 "A node in the computation graph"

--- a/src/compute-nodes.jl
+++ b/src/compute-nodes.jl
@@ -7,6 +7,9 @@
 #
 
 import Base: map, reduce, mapreduce, filter, IdFun
+if VERSION >= v"0.5.0-"
+import Base: foreach
+end
 
 export broadcast, distribute, reducebykey, mappart, foreach
 


### PR DESCRIPTION
- Getting accumulator id with `rand` can potentially overwrite another valid accumulator, very easily when the random seed is reset for some reason. Using a one up counter instead.
- New method to clear accumulators. Otherwise they leak memory (self-referenced in a global dict)

Also:
- remove Julia 0.5 deprcation warnings (use Compat)
- add wordcount on files to examples (by @shashi)