### PR TITLE
Use isa instead of typeof in show

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -85,7 +85,7 @@ end
 
 
 function show(io::IO, x::MapReduce)
-    if typeof(x.f, IdFun)
+    if isa(x.f, IdFun)
         show_mrnode(io, "reduce", x.op, x.v0, x.input)
     else
         show_mrnode(io, "mapreduce", x.f, x.op, x.v0, x.input)
@@ -93,7 +93,7 @@ function show(io::IO, x::MapReduce)
 end
 
 function show(io::IO, x::MapReduce)
-    if typeof(x.f, IdFun)
+    if isa(x.f, IdFun)
         show_mrnode(io, "reducebykey", x.op, x.v0, x.input)
     else
         show_mrnode(io, "mapreducebykey", x.f, x.op, x.v0, x.input)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,3 +8,4 @@ using BaseTestNext
 include("util.jl")
 include("distribute.jl")
 include("redistribute.jl")
+include("show.jl")

--- a/test/show.jl
+++ b/test/show.jl
@@ -1,0 +1,8 @@
+a = rand(10,10)
+b = distribute(a)
+c = ComputeFramework.map(x -> x^2, b)
+d = reduce(+, 0.0, c)
+
+@test show(IOBuffer(), b) == 1
+@test show(IOBuffer(), c) == 1
+@test show(IOBuffer(), d) == 1


### PR DESCRIPTION
Couldn't show the `mapredure` from the readme.

I couldn't run the test on either 0.4 and 0.5, but I had to give up on fixing that. It might be a good idea to enable Travis testing and code coverage.