### PR TITLE
Update REQUIRE to include Logging

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.4
 Compat
+Logging


### PR DESCRIPTION
Trying to use the package if Logging isn't installed raises a LoadError.