### PR TITLE
Added generic children function

### DIFF
--- a/src/array/alloc.jl
+++ b/src/array/alloc.jl
@@ -13,7 +13,7 @@ function stage(ctx, a::AllocateArray)
         _alloc(sz) = f(eltype, sz)
     end
 
-    subdomains = branch.children
+    subdomains = children(branch)
     thunks = similar(subdomains, Thunk)
     for i=eachindex(subdomains)
         thunks[i] = Thunk(alloc, (size(subdomains[i]),))

--- a/src/array/matrix.jl
+++ b/src/array/matrix.jl
@@ -230,6 +230,6 @@ function stage(ctx, scal::Scale)
 
     @assert size(domain(r), 1) == size(domain(l), 1)
 
-    parts = _scale(parts(l), parts(r))
-    Cat(partition(r), Any, domain(r), parts)
+    scal_parts = _scale(parts(l), parts(r))
+    Cat(partition(r), Any, domain(r), scal_parts)
 end

--- a/src/array/operators.jl
+++ b/src/array/operators.jl
@@ -10,7 +10,7 @@ import Base: exp, expm1, log, log10, log1p, sqrt, cbrt, exponent,
 
 blockwise_unary = [:exp, :expm1, :log, :log10, :log1p, :sqrt, :cbrt, :exponent, :significand,
          :(-),
-         :sin, :sinpi, :cos, :cospi, :tan, :sec, :cot, :csc, 
+         :sin, :sinpi, :cos, :cospi, :tan, :sec, :cot, :csc,
          :sinh, :cosh, :tanh, :coth, :sech, :csch,
          :asin, :acos, :atan, :acot, :asec, :acsc,
          :asinh, :acosh, :atanh, :acoth, :asech, :acsch, :sinc, :cosc]
@@ -43,7 +43,7 @@ end
 function stage(ctx, node::BlockwiseOp)
     inputs = Any[cached_stage(ctx, n) for n in node.input]
     primary = inputs[1] # all others will align to this guy
-    domains = domain(primary).children
+    domains = children(domain(primary))
     thunks = similar(domains, Any)
     f = node.f
     for i=eachindex(domains)

--- a/src/compute.jl
+++ b/src/compute.jl
@@ -102,9 +102,9 @@ end
 If a Cat tree has a Thunk in it, make the whole thing a big thunk
 """
 function thunkize(ctx, c::Cat)
-    if any(istask, c.parts)
-        thunks = map(x -> thunkize(ctx, x), c.parts)
-        sz = size(c.parts)
+    if any(istask, parts(c))
+        thunks = map(x -> thunkize(ctx, x), parts(c))
+        sz = size(parts(c))
         Thunk(thunks; meta=true) do results...
             t = parttype(results[1])
             Cat(partition(c), t, domain(c), reshape(AbstractPart[results...], sz))
@@ -251,7 +251,7 @@ Input: dependents dict
 function noffspring(dpents::Dict)
     Pair[node => noffspring(node, dpents) for node in keys(dpents)] |> Dict
 end
- 
+
 function noffspring(n, dpents)
     ds = get(dpents, n, Set()) # dependents of n
     length(dpents[n]) + reduce(+, 0, [noffspring(d, dpents)

--- a/src/domain.jl
+++ b/src/domain.jl
@@ -103,6 +103,8 @@ isempty(a::DomainBranch) = isempty(head(a))
 intersect{D<:Domain}(a::DomainBranch{D}, b::D) = intersect(head(a), b)
 project{D<:Domain}(a::DomainBranch{D}, b::D) = intersect(head(a), b)
 getindex{D<:Domain}(a::DomainBranch{D}, b::D) = getindex(head(a), b)
+children(x::DomainBranch) = x.children
+
 
 
 ###### Array Domains ######
@@ -120,6 +122,7 @@ DenseDomain(xs...) = DenseDomain(xs)
 DenseDomain(xs::Array) = DenseDomain((xs...,))
 
 indexes(a::DenseDomain) = a.indexes
+children(a::DenseDomain) = a
 
 domain(x::DenseArray) = DenseDomain(map(l -> 1:l, size(x)))
 
@@ -147,8 +150,8 @@ alignfirst(a::ArrayDomain) =
 
 function alignfirst{T<:ArrayDomain}(a::DomainBranch{T})
     h = alignfirst(head(a))
-    children = map(alignfirst, a.children)
-    DomainBranch(h, cumulative_domains(children))
+    cdren = map(alignfirst, children(a))
+    DomainBranch(h, cumulative_domains(cdren))
 end
 
 # Some utility functions specific to domains of arrays

--- a/src/file-io.jl
+++ b/src/file-io.jl
@@ -87,7 +87,7 @@ function save(ctx, io::IO, part::Cat, file_path)
 
     # save the children
     saved_children = [save(ctx, c, joinpath(dir_path, lpad(i, 4, "0")))
-        for (i, c) in enumerate(part.parts)]
+        for (i, c) in enumerate(parts(part))]
 
     save(ctx, io, part, file_path, saved_children)
     # write each child
@@ -250,12 +250,12 @@ function stage(ctx, s::Save)
         saved
     end
 
-    saved_parts = similar(x.parts, Thunk)
-    for i=1:length(x.parts)
-        saved_parts[i] = Thunk(save_part, (i, x.parts[i]))
+    saved_parts = similar(parts(x), Thunk)
+    for i=1:length(parts(x))
+        saved_parts[i] = Thunk(save_part, (i, parts(x)[i]))
     end
 
-    sz = size(x.parts)
+    sz = size(parts(x))
     function save_cat_meta(parts...)
         f = open(s.name, "w")
         saved_parts = reshape(AbstractPart[c for c in parts], sz)

--- a/src/map-reduce.jl
+++ b/src/map-reduce.jl
@@ -12,7 +12,7 @@ end
 function stage(ctx, node::Map)
     inputs = Any[cached_stage(ctx, n) for n in node.inputs]
     primary = inputs[1] # all others will align to this guy
-    domains = domain(primary).children
+    domains = children(domain(primary))
     thunks = similar(domains, Any)
     f = node.f
     for i=eachindex(domains)
@@ -39,7 +39,7 @@ end
 
 function stage(ctx, r::ReduceBlock)
     inp = stage(ctx, r.input)
-    reduced_parts = map(x -> Thunk(r.op, (x,); get_result=r.get_result), inp.parts)
+    reduced_parts = map(x -> Thunk(r.op, (x,); get_result=r.get_result), parts(inp))
     Thunk((xs...) -> r.op_master(xs), (reduced_parts...); meta=true)
 end
 

--- a/src/part.jl
+++ b/src/part.jl
@@ -11,6 +11,8 @@ memory / storage / network location.
 """
 abstract AbstractPart
 
+parts(x::AbstractPart) = x
+
 """
     gather(context, part::AbstractPart)
 
@@ -127,12 +129,13 @@ end
 domain(c::Cat) = c.domain
 parttype(c::Cat) = c.parttype
 partition(c::Cat) = c.partition
+parts(x::Cat) = x.parts
 
 function gather(ctx, part::Cat)
 
     cat_data(partition(part),
         part.domain,
-        map(c->gather(ctx,c), part.parts))
+        map(c->gather(ctx,c), parts(part)))
 end
 
 """
@@ -145,7 +148,7 @@ cat(p::PartitionScheme, T::Type, d::Domain, parts::AbstractArray) =
 `sub` of a `Cat` part returns a `Cat` of sub parts
 """
 function sub(c::Cat, d)
-    parts, subdomains = lookup_parts(c.parts, domain(c).children, d)
+    parts, subdomains = lookup_parts(parts(c), children(domain(c)), d)
     if length(parts) == 1
         return parts[1]
     end

--- a/src/partition.jl
+++ b/src/partition.jl
@@ -93,7 +93,7 @@ function cat_data(p::BlockPartition, dom::DomainBranch, parts::AbstractArray)
     T = eltype(parts[1])
     arr = Array(T, size(dom))
     fdom = alignfirst(dom)
-    for (d, part) in zip(fdom.children, parts)
+    for (d, part) in zip(children(fdom), parts)
         arr[indexes(d)...] = part
     end
     arr

--- a/src/read-delim.jl
+++ b/src/read-delim.jl
@@ -24,8 +24,8 @@ function stage(ctx, rd::ReadDelim)
     end
     # figure out number of columns
     Thunk((thunks...); meta=true) do ps...
-        parts = [ps...]
-        ds = map(domain, parts)
+        ps_parts = [ps...]
+        ds = map(domain, ps_parts)
         ncols = size(ds[1], 2)
         nrows_parts = map(d->size(d, 1), ds)
         nrows = sum(nrows_parts)

--- a/src/show.jl
+++ b/src/show.jl
@@ -5,8 +5,7 @@ function Base.show{B<:BlockPartition}(io::IO, c::Cat{B})
     write(io, ' ')
     write(io, string(parttype(c)))
     write(io, " in ")
-    write(io, showsz(size(c.parts)))
+    write(io, showsz(size(parts(c))))
     write(io, " parts each of (max size) ")
     write(io, showsz(partition(c).blocksize))
 end
-

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -9,6 +9,7 @@ end
 size(d::SparseCSCDomain, arg...) = size(d.adomain, arg...)
 length(d::SparseCSCDomain) = Int(d.colptr[end]-1)
 indexranges(d::SparseCSCDomain) = indexranges(d.adomain)
+children(d::SparseCSCDomain) = d
 
 function alignfirst(d::SparseCSCDomain)
     adomain = alignfirst(d.adomain)
@@ -122,4 +123,3 @@ end
 # Workaround because cat(n, a, b) returns a dense array
 cat(::SliceDimension{1}, a::SparseMatrixCSC, b::SparseMatrixCSC) = vcat(a, b)
 cat(::SliceDimension{2}, a::SparseMatrixCSC, b::SparseMatrixCSC) = hcat(a, b)
-

--- a/test/array.jl
+++ b/test/array.jl
@@ -1,3 +1,4 @@
+import ComputeFramework: children, parts
 
 @testset "Arrays" begin
 
@@ -10,10 +11,10 @@
         @test isa(X1, ComputeFramework.Cat)
         @test X2 |> size == (100, 100)
         @test all(X2 .>= 0.0)
-        @test size(X1.parts) == (10, 10)
+        @test size(parts(X1)) == (10, 10)
         @test domain(X1).head == DenseDomain(1:100, 1:100)
-        @test domain(X1).children |> size == (10, 10)
-        @test domain(X1).children == partition(BlockPartition(10, 10), DenseDomain(1:100, 1:100)).children
+        @test children(domain(X1)) |> size == (10, 10)
+        @test children(domain(X1)) == children(partition(BlockPartition(10, 10), DenseDomain(1:100, 1:100)))
     end
     X = rand(BlockPartition(10, 10), 100, 100)
     test_rand(X)
@@ -31,9 +32,9 @@ end
         X1 = Distribute(BlockPartition(10, 20), X)
         @test gather(X1) == X
         Xc = compute(X1).result
-        @test Xc.parts |> size == (10, 5)
-        @test domain(Xc).children |> size == (10, 5)
-        @test map(x->size(x) == (10, 20), domain(Xc).children) |> all
+        @test parts(Xc) |> size == (10, 5)
+        @test children(domain(Xc)) |> size == (10, 5)
+        @test map(x->size(x) == (10, 20), children(domain(Xc))) |> all
     end
     test_dist(rand(100, 100))
     test_dist(sprand(100, 100, 0.1))
@@ -45,9 +46,9 @@ end
         X1 = Distribute(BlockPartition(10, 20), X)
         @test gather(X1') == X'
         Xc = compute(X1').result
-        @test Xc.parts |> size == (div(y, 20), div(x,10))
-        @test domain(Xc).children |> size == (div(y, 20), div(x, 10))
-        @test map(x->size(x) == (20, 10), domain(Xc).children) |> all
+        @test parts(Xc) |> size == (div(y, 20), div(x,10))
+        @test children(domain(Xc)) |> size == (div(y, 20), div(x, 10))
+        @test map(x->size(x) == (20, 10), children(domain(Xc))) |> all
     end
     test_transpose(rand(100, 100))
     test_transpose(rand(100, 120))
@@ -64,10 +65,10 @@ end
         X3 = compute(X1*X1').result
         @test norm(gather(X2) - X'X) < tol
         @test norm(gather(X3) - X*X') < tol
-        @test X2.parts |> size == (2, 2)
-        @test X3.parts |> size == (4, 4)
-        @test map(x->size(x) == (20, 20), domain(X2).children) |> all
-        @test map(x->size(x) == (10, 10), domain(X3).children) |> all
+        @test parts(X2) |> size == (2, 2)
+        @test parts(X3) |> size == (4, 4)
+        @test map(x->size(x) == (20, 20), children(domain(X2))) |> all
+        @test map(x->size(x) == (10, 10), children(domain(X3))) |> all
     end
     test_mul(rand(40, 40))
 end


### PR DESCRIPTION
I've added a generic children function that returns the `children` field for `DomainBranch` and indices for the other `Domain` sub-types.

This should prevent `stage` from relying on all Domain sub-types having a `children` field. (#21)