### PR TITLE
timing and profiling

### DIFF
--- a/src/ComputeFramework.jl
+++ b/src/ComputeFramework.jl
@@ -1,22 +1,9 @@
 module ComputeFramework
 
-# enable logging only during debugging
-using Logging
-const logger = Logging.configure(level=DEBUG)
-#const logger = Logging.configure(filename="/tmp/blobs$(getpid()).log", level=DEBUG)
-
-macro logmsg(s)
-    quote
-        debug($(esc(s)))
-    end
-end
-#=
-macro logmsg(s)
-end
-=#
-
+using Compat
 
 include("util.jl")
+include("logging.jl")
 
 # Data and sub-data
 include("domain.jl")

--- a/src/array/operators.jl
+++ b/src/array/operators.jl
@@ -44,12 +44,10 @@ function stage(ctx, node::BlockwiseOp)
     inputs = Any[cached_stage(ctx, n) for n in node.input]
     primary = inputs[1] # all others will align to this guy
     domains = children(domain(primary))
-    thunks = similar(domains, Any)
-    f = node.f
-    for i=eachindex(domains)
-        inps = map(inp->sub(inp, domains[i]), inputs)
-        thunks[i] = Thunk(f, inps)
+    thunks = map(map(parts, inputs)...) do args...
+        Thunk(node.f, args)
     end
+
     Cat(partition(primary), Any, domain(primary), thunks)
 end
 

--- a/src/compute.jl
+++ b/src/compute.jl
@@ -27,8 +27,7 @@ identity, for example:
     A = rand(BlockPartition(100,100), Float64, 1000, 1000)
     compute(A+A')
 
-will should not return in computation of A twice because
-we are staging A multiple times.
+must not result in computation of A twice.
 """
 function cached_stage(ctx, x)
     if haskey(_stage_cache, (ctx, x))

--- a/src/part.jl
+++ b/src/part.jl
@@ -201,3 +201,13 @@ function lookup_parts{T,N}(parts, part_domains::Array{T,N}, d)
     end
     subparts, cumulative_domains(map(alignfirst, intersects2))
 end
+
+
+# Dammit ref counting is probably needed
+
+release_part(x::Cat) = map(release_part, x.parts)
+## WARNING: a token may be held by many. It should never be
+release_part(s::Part{DistMem}) = begin
+    release_token(s.handle.ref)
+end
+release_part(s::AbstractPart) = nothing

--- a/src/partition.jl
+++ b/src/partition.jl
@@ -76,7 +76,7 @@ end
 BlockPartition(xs...) = BlockPartition(xs)
 
 @generated function partition{N}(p::BlockPartition{N}, dom::ArrayDomain{N})
-    sym(n) = symbol("i$n")
+    sym(n) = Symbol("i$n")
 
     forspec = [:($(sym(i)) = split_range_interval(
             idxs[$i], p.blocksize[$i])) for i=1:N]

--- a/src/processor.jl
+++ b/src/processor.jl
@@ -1,3 +1,4 @@
+import Base.procs
 export OSProc, Context
 
 abstract Processor
@@ -13,13 +14,25 @@ end
 A context represents a set of processors to use
 for a papply operation.
 """
-immutable Context
+type Context
     procs::Array{Processor}
+    log_sink::Any
+    profile::Bool
+end
+
+function Context(xs)
+    Context(xs, NoOpLog(), false) # By default don't log events
 end
 Context(xs::Array{Int}) = Context(map(OSProc, xs))
 Context() = Context(workers())
 procs(c::Context) = c.procs
 
+"""
+Write a log event
+"""
+function write_event(ctx::Context, event::Event)
+    write_event(ctx.log_sink, event)
+end
 #gather(x::AbstractPart) = gather(Context(), x)
 
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,4 +1,4 @@
-
+import Base: convert
 
 ###### Filesize algebra ######
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -109,3 +109,14 @@ function treereduce(f, xs)
     m = div(l, 2)
     f(treereduce(f, xs[1:m]), treereduce(f, xs[m+1:end]))
 end
+
+const  ENABLE_DEBUG = true # Will remove code under @dbg
+
+"""
+Run a block of code only if DEBUG is true
+"""
+macro dbg(expr)
+    if ENABLE_DEBUG
+        esc(expr)
+    end
+end


### PR DESCRIPTION
See docs in README

This is also going to be the basis of the performance UI. One can create many types of `log_sink` objects (arrays, channels, remotechannels) to aggregate metadata about small chunks of work occurring in parallel. You can collect profiling samples from select events and pretty-print them.

I am trying to understand why this stuff is so slow with profiling turned on.

cc @ViralBShah 