### PR TITLE
Improvements to domain bookkeeping and getindex

### DIFF
--- a/src/array/alloc.jl
+++ b/src/array/alloc.jl
@@ -18,7 +18,7 @@ function stage(ctx, a::AllocateArray)
     for i=eachindex(subdomains)
         thunks[i] = Thunk(alloc, (size(subdomains[i]),))
     end
-    cat(a.partition, Array{a.eltype, dims}, branch, thunks)
+    Cat(Array{a.eltype, dims}, branch, thunks)
 end
 
 function Base.rand(p::PartitionScheme, eltype::Type, dims)

--- a/src/array/map-reduce.jl
+++ b/src/array/map-reduce.jl
@@ -19,7 +19,7 @@ function stage(ctx, node::Map)
         inps = map(inp->sub(inp, domains[i]), inputs)
         thunks[i] = Thunk((args...) -> map(f, args...), (inps...))
     end
-    Cat(partition(primary), Any, domain(primary), thunks)
+    Cat(Any, domain(primary), thunks)
 end
 
 map(f, xs::Computation...) = Map(f, xs)
@@ -110,5 +110,5 @@ function stage(ctx, r::Reducedim)
     colons[[r.dims...]] = 1
     dmn = c[colons...]
     d = DomainSplit(reducedim(head(domain(inp)), r.dims), map(d->reducedim(d, r.dims), dmn))
-    Cat(partition(inp), parttype(inp),d, thunks)
+    Cat(parttype(inp),d, thunks)
 end

--- a/src/array/matrix.jl
+++ b/src/array/matrix.jl
@@ -99,15 +99,7 @@ function (*)(a::ArrayDomain{2}, b::ArrayDomain{1})
 end
 
 function (*)(a::DomainSplit, b::DomainSplit)
-    try
-        DomainSplit(head(a)*head(b), _mul(parts(a), parts(b)))
-    catch err
-        if isa(err, DimensionMismatch)
-            throw(DimensionMismatch("Objects being multiplied have incompatible block distributions"))
-        else
-            rethrow(err)
-        end
-    end
+    DomainSplit(head(a)*head(b), parts(a) * parts(b))
 end
 
 function (*)(a::BlockPartition{2}, b::BlockPartition{2})

--- a/src/array/matrix.jl
+++ b/src/array/matrix.jl
@@ -67,8 +67,7 @@ end
 =#
 
 function stage(ctx, d::Distribute)
-    p = part(d.data)
-    Cat(typeof(d.data), d.domain, map(c -> sub(p, c), parts(d.domain)))
+    Cat(parttype(d.data), d.domain, map(c -> sub(d.data, c), parts(d.domain)))
 end
 
 

--- a/src/array/operators.jl
+++ b/src/array/operators.jl
@@ -48,7 +48,7 @@ function stage(ctx, node::BlockwiseOp)
         Thunk(node.f, args)
     end
 
-    Cat(partition(primary), Any, domain(primary), thunks)
+    Cat(Any, domain(primary), thunks)
 end
 
 export mappart

--- a/src/array/show.jl
+++ b/src/array/show.jl
@@ -1,11 +1,10 @@
 
 showsz(sz) = join(sz, "x")
-function Base.show{B<:BlockPartition}(io::IO, c::Cat{B})
+function Base.show(io::IO, c::Cat)
     write(io, showsz(size(domain(c))))
     write(io, ' ')
     write(io, string(parttype(c)))
     write(io, " in ")
     write(io, showsz(size(parts(c))))
-    write(io, " parts each of (max size) ")
-    write(io, showsz(partition(c).blocksize))
+    write(io, " parts")
 end

--- a/src/basics/compute.jl
+++ b/src/basics/compute.jl
@@ -145,7 +145,7 @@ function thunkize(ctx, c::Cat)
         sz = size(parts(c))
         Thunk(thunks; meta=true) do results...
             t = parttype(results[1])
-            Cat(partition(c), t, domain(c), reshape(AbstractPart[results...], sz))
+            Cat(t, domain(c), reshape(AbstractPart[results...], sz))
         end
     else
         c

--- a/src/basics/data.jl
+++ b/src/basics/data.jl
@@ -177,6 +177,7 @@ function group_indices(cumlength, idxs::Range)
     map(=>, f:l, map(UnitRange, vcat(first(idxs), out[1:end-1]+1), out))
 end
 
+_cumsum(x::AbstractArray) = length(x) == 0 ? Int[] : cumsum(x)
 function lookup_parts{N}(ps::AbstractArray, subdmns::BlockedDomains{N}, d::DenseDomain{N})
     groups = map(group_indices, subdmns.cumlength, indexes(d))
     sz = map(length, groups)
@@ -187,7 +188,7 @@ function lookup_parts{N}(ps::AbstractArray, subdmns::BlockedDomains{N}, d::Dense
         dmn = DenseDomain(map(x->x[2], idx_and_dmn))
         pieces[i] = sub(ps[idx...], project(subdmns[idx...], dmn))
     end
-    out_cumlength = map(g->cumsum(map(x->length(x[2]), g)), groups)
+    out_cumlength = map(g->_cumsum(map(x->length(x[2]), g)), groups)
     out_dmn = BlockedDomains(ntuple(x->1,Val{N}), out_cumlength)
     pieces, out_dmn
 end

--- a/src/basics/data.jl
+++ b/src/basics/data.jl
@@ -134,7 +134,7 @@ parts(x::Cat) = x.parts
 persist!(x::Cat) = (for p in parts(x); persist!(p); end)
 
 function gather(ctx, part::Cat)
-    cat_data(part.domain, map(c->gather(ctx,c), parts(part)))
+    cat_data(parttype(part), part.domain, map(c->gather(ctx,c), parts(part)))
 end
 
 """

--- a/src/basics/data.jl
+++ b/src/basics/data.jl
@@ -120,11 +120,9 @@ A collection of Parts put together to form a bigger logical part
 Fields:
  - parttype: The type of the data represented by the Cat
  - domain: The domain of the combined part and parts (`DomainSplit`)
- - partition: The partition scheme used to divide child parts into a big part
  - parts: the parts which form the parts of the Cat
 """
-type Cat{P<:PartitionScheme} <: AbstractPart
-    partition::P
+type Cat <: AbstractPart
     parttype::Type
     domain::DomainSplit
     parts::AbstractArray
@@ -132,22 +130,12 @@ end
 
 domain(c::Cat) = c.domain
 parttype(c::Cat) = c.parttype
-partition(c::Cat) = c.partition
 parts(x::Cat) = x.parts
 persist!(x::Cat) = (for p in parts(x); persist!(p); end)
 
 function gather(ctx, part::Cat)
-
-    cat_data(partition(part),
-        part.domain,
-        map(c->gather(ctx,c), parts(part)))
+    cat_data(part.domain, map(c->gather(ctx,c), parts(part)))
 end
-
-"""
-Concatenate parts according to some partition
-"""
-cat(p::PartitionScheme, T::Type, d::Domain, parts::AbstractArray) =
-        Cat(p, T, d, parts)
 
 """
 `sub` of a `Cat` part returns a `Cat` of sub parts
@@ -158,7 +146,7 @@ function sub(c::Cat, d)
         return c_parts[1]
     end
 
-    cat(partition(c), parttype(c), DomainSplit(alignfirst(d), subdomains), c_parts)
+    Cat(parttype(c), DomainSplit(alignfirst(d), subdomains), c_parts)
 end
 
 function getdim(vec)

--- a/src/basics/data.jl
+++ b/src/basics/data.jl
@@ -141,12 +141,12 @@ end
 `sub` of a `Cat` part returns a `Cat` of sub parts
 """
 function sub(c::Cat, d)
-    c_parts, subdomains = lookup_parts(parts(c), parts(domain(c)), d)
-    if length(c_parts) == 1
-        return c_parts[1]
+    sub_parts, subdomains = lookup_parts(parts(c), parts(domain(c)), d)
+    if length(sub_parts) == 1
+        sub_parts[1]
+    else
+        Cat(parttype(c), alignfirst(DomainSplit(d, subdomains)), sub_parts)
     end
-
-    Cat(parttype(c), DomainSplit(alignfirst(d), subdomains), c_parts)
 end
 
 function getdim(vec)

--- a/src/basics/domain.jl
+++ b/src/basics/domain.jl
@@ -2,7 +2,7 @@
 export domain, Domain, UnitDomain, project, alignfirst, DenseDomain
 
 import Base: isempty, getindex, intersect,
-             ==, size, length
+             ==, size, length, ndims
 
 ###### Domain ######
 

--- a/src/basics/domain.jl
+++ b/src/basics/domain.jl
@@ -34,8 +34,8 @@ Find the intersection of two domains. For example,
 
 Align `b` relative to `a`. For example,
 
-    project(DenseDomain(15:20, 30:40), DenseDomain(11:25, 21:100)
-    # => DenseDomain{2}((-3:11,-8:71))
+    julia> project(DenseDomain(11:25, 21:100), DenseDomain(15:20, 30:40))
+    ComputeFramework.DenseDomain{2}((5:10,10:20))
 """
 @unimplemented project{D<:Domain}(d::D, b::D)
 

--- a/src/basics/domain.jl
+++ b/src/basics/domain.jl
@@ -169,3 +169,31 @@ domain(x::AbstractArray) = DenseDomain([1:l for l in size(x)])
 
 Base.@deprecate_binding DomainBranch DomainSplit
 Base.@deprecate children(x::Domain) parts(x)
+
+"""
+    cat_data(p::PartitionScheme, a...)
+
+Put data objects back together as if they were split using a `PartitionScheme`
+"""
+@unimplemented cat_data(t::Type, dom::Domain, parts)
+
+function cat_data{A<:ArrayDomain}(
+    dom::DomainSplit{A},
+    ps::AbstractArray)
+
+    if isa(ps[1], SparseMatrixCSC)
+        return sparse_cat_data(ps)
+    end
+    T = eltype(ps[1])
+    arr = Array(T, size(dom))
+    for (d, part) in zip(parts(dom), ps)
+        setindex!(arr, part, indexes(d)...)
+    end
+    arr
+end
+
+function sparse_cat_data(ps)
+    hblocks = Any[hcat(ps[i, :]...) for i=1:size(ps,1)]
+
+    vcat(hblocks...)
+end

--- a/src/basics/file-io.jl
+++ b/src/basics/file-io.jl
@@ -68,7 +68,7 @@ end
 
 function save(ctx, io::IO, part::Cat, file_path::AbstractString, saved_parts::AbstractArray)
 
-    metadata = (partition(part), parttype(part), domain(part), saved_parts)
+    metadata = (parttype(part), domain(part), saved_parts)
 
     # save yourself
     write(io, CAT)

--- a/src/basics/partition.jl
+++ b/src/basics/partition.jl
@@ -47,14 +47,30 @@ immutable BlockPartition{N} <: PartitionScheme
 end
 BlockPartition(xs...) = BlockPartition(xs)
 
-@generated function partition{N}(p::BlockPartition{N}, dom::ArrayDomain{N})
-    sym(n) = Symbol("i$n")
+# @generated function partition{N}(p::BlockPartition{N}, dom::ArrayDomain{N})
+#     sym(n) = Symbol("i$n")
 
-    forspec = [:($(sym(i)) = split_range_interval(
-            idxs[$i], p.blocksize[$i])) for i=1:N]
+#     forspec = [:($(sym(i)) = split_range_interval(
+#             idxs[$i], p.blocksize[$i])) for i=1:N]
 
-    subdmn = Expr(:call, :DenseDomain, [sym(n) for n=1:N]...)
-    body = Expr(:comprehension, subdmn, forspec...)
-    Expr(:block, :(idxs = indexes(dom)), :(DomainSplit(dom, $body)))
+#     subdmn = Expr(:call, :DenseDomain, [sym(n) for n=1:N]...)
+#     body = Expr(:comprehension, subdmn, forspec...)
+#     Expr(:block, :(idxs = indexes(dom)), :(DomainSplit(dom, $body)))
+# end
+
+function _cumlength(len, step)
+    nice_pieces = div(len, step)
+    extra = rem(len, step)
+    if extra > 0
+        vcat([step for i=1:nice_pieces], extra)
+    else
+        [step for i=1:nice_pieces]
+    end |> cumsum
 end
 
+include("../lib/blocked-domains.jl")
+function partition(p::BlockPartition, dom::ArrayDomain)
+    ps = BlockedDomains(map(first, indexes(dom)),
+        map(_cumlength, map(length, indexes(dom)), p.blocksize))
+    DomainSplit(dom, ps)
+end

--- a/src/lib/blocked-domains.jl
+++ b/src/lib/blocked-domains.jl
@@ -1,0 +1,68 @@
+using ComputeFramework
+
+import Base: ndims, size, getindex
+immutable BlockedDomains{N} <: AbstractArray{DenseDomain{N}, N}
+    start::NTuple{N, Int}
+    cumlength::NTuple{N, AbstractArray{Int}}
+end
+
+ndims{N}(x::BlockedDomains{N}) = N
+size(x::BlockedDomains) = map(length, x.cumlength)
+function _getindex{N}(x::BlockedDomains{N}, idx::Tuple)
+    starts = map((vec, i) -> i == 0 ? 0 : getindex(vec,i), x.cumlength, map(x->x-1, idx))
+    ends = map(getindex, x.cumlength, idx)
+    DenseDomain(map(UnitRange, map(+, starts, x.start), map((x,y)->x+y-1, ends, x.start)))
+end
+
+function getindex{N}(x::BlockedDomains{N}, idx::Int)
+    if N == 1
+        _getindex(x, (idx,))
+    else
+        _getindex(x, ind2sub(x, idx))
+    end
+end
+
+getindex(x::BlockedDomains, idx::Int...) = _getindex(x,idx)
+
+Base.linearindexing(x::BlockedDomains) = Base.LinearSlow()
+
+function Base.ctranspose(x::BlockedDomains{2})
+    BlockedDomains(reverse(x.start), reverse(x.cumlength))
+end
+
+function Base.(:*)(x::BlockedDomains{2}, y::BlockedDomains{2})
+    if x.cumlength[2] != y.cumlength[1]
+        throw(DimensionMismatch("Block distributions being multiplied are not compatible"))
+    end
+    BlockedDomains((x.start[1],y.start[2]), (x.cumlength[1], y.cumlength[2]))
+end
+
+function Base.(:*)(x::BlockedDomains{2}, y::BlockedDomains{1})
+    if x.cumlength[2] != y.cumlength[1]
+        throw(DomainError("Block distributions being multiplied are not compatible"))
+    end
+    BlockedDomains((x.start[1],), (x.cumlength[1],))
+end
+
+merge_cumsums(x,y) = vcat(x, y+x[end])
+
+function Base.cat(idx::Int, x::BlockedDomains, y::BlockedDomains)
+    N = max(ndims(x), ndims(y))
+    _get(x::Tuple, i, def) = length(x) <= i ? x[i] : def
+    get_i(x,y, i) = _get(x.cumlength, i, _get(y.cumlength, i, Int[]))
+    for i=1:N
+        i == idx && continue
+        if get_i(x,y,i) != get_i(y,x,i)
+            @show get_i(x,y,i), get_i(y,x,i)
+            throw(DimensionMismatch("Blocked domains being concatenated have different distributions along dimension $i"))
+        end
+    end
+    output = Any[x.cumlength...]
+    output[idx] = merge_cumsums(x.cumlength[idx], y.cumlength[idx])
+    BlockedDomains(x.start, (output...))
+end
+
+Base.hcat(xs::BlockedDomains...) = cat(2, xs...)
+Base.vcat(xs::BlockedDomains...) = cat(1, xs...)
+
+cumulative_domains(x::BlockedDomains) = x

--- a/src/lib/blocked-domains.jl
+++ b/src/lib/blocked-domains.jl
@@ -48,12 +48,10 @@ merge_cumsums(x,y) = vcat(x, y+x[end])
 
 function Base.cat(idx::Int, x::BlockedDomains, y::BlockedDomains)
     N = max(ndims(x), ndims(y))
-    _get(x::Tuple, i, def) = length(x) <= i ? x[i] : def
-    get_i(x,y, i) = _get(x.cumlength, i, _get(y.cumlength, i, Int[]))
+    get_i(x,y, i) = length(x) <= i ? x[i] : length(y) <= i ? y[i] : Int[]
     for i=1:N
         i == idx && continue
         if get_i(x,y,i) != get_i(y,x,i)
-            @show get_i(x,y,i), get_i(y,x,i)
             throw(DimensionMismatch("Blocked domains being concatenated have different distributions along dimension $i"))
         end
     end

--- a/test/array.jl
+++ b/test/array.jl
@@ -101,4 +101,28 @@ end
     @test Diagonal(y)*x == gather(scale(y, X))
 end
 
+@testset "Getindex" begin
+    function test_getindex(x)
+        X = Distribute(BlockPartition(3,3), x)
+        @test gather(X[3:8, 2:7]) == x[3:8, 2:7]
+        ragged_idx = [1,2,9,7,6,2,4,5]
+        @test gather(X[ragged_idx, 2:7]) == x[ragged_idx, 2:7]
+        @test gather(X[ragged_idx, reverse(ragged_idx)]) == x[ragged_idx, reverse(ragged_idx)]
+        ragged_idx = [1,2,9,7,6,2,4,5]
+        @test gather(X[[2,7,10], :]) == x[[2,7,10], :]
+        @test gather(X[[], ragged_idx]) == x[[], ragged_idx]
+        @test gather(X[[], []]) == x[[], []]
+
+        @testset "dimensionality reduction" begin
+        # THESE NEED FIXING!!
+            @test vec(gather(X[ragged_idx, 5])) == vec(x[ragged_idx, 5])
+            @test vec(gather(X[5, ragged_idx])) == vec(x[5, ragged_idx])
+            @test gather(X[5, 5])[1] == x[5,5]
+        end
+    end
+
+    test_getindex(rand(10,10))
+    test_getindex(sprand(10,10,0.5))
+end
+
 end

--- a/test/array.jl
+++ b/test/array.jl
@@ -76,6 +76,11 @@ end
         @test map(x->size(x) == (10, 10), parts(domain(X3))) |> all
     end
     test_mul(rand(40, 40))
+
+    x = rand(10,10)
+    X = Distribute(BlockPartition(3,3), x)
+    y = rand(10)
+    @test norm(gather(X*y) - x*y) < 1e-13
 end
 
 @testset "concat" begin
@@ -86,6 +91,14 @@ end
     @test vcat(m,m) == gather(vcat(x,x))
     @test hcat(m,m) == gather(hcat(x,y))
     @test_throws DimensionMismatch compute(vcat(x,y))
+end
+
+@testset "scale" begin
+    x = rand(10,10)
+    X = Distribute(BlockPartition(3,3), x)
+    y = rand(10)
+
+    @test Diagonal(y)*x == gather(scale(y, X))
 end
 
 end


### PR DESCRIPTION
- Introduces new `BlockedDomains <: AbstractArray` type which stores blocked distribution as a vector of cumulative lengths along each dimension. Benefits: wayy lesser possible inconsistent states, faster, safer to search for things in.
- delete old code with `@generated` and complicated code to do with plain array of domains
- Distribute now holds the distribution instead of partition type
- Cat no more holds the partition - lots of awkwardness removed.
- GetIndex now has more features (repeated indices, random order), and is faster (asymptotically `O(area)` to `O(log(perimeter))`, for lookups if that makes sense))
- tests for getindex